### PR TITLE
Removed tqdm from pipeline.py

### DIFF
--- a/gliclass/pipeline.py
+++ b/gliclass/pipeline.py
@@ -1,15 +1,13 @@
 import torch
 from tqdm import tqdm
-import numpy as np
 from transformers import AutoTokenizer
 from abc import ABC, abstractmethod
 
 from .model import GLiClassModel, GLiClassBiEncoder
-from .config import GLiClassModelConfig
 
 class BaseZeroShotClassificationPipeline(ABC):
     def __init__(self, model, tokenizer, max_classes=25, max_length=1024, 
-                                classification_type='multi-label', device='cuda:0'):
+                                classification_type='multi-label', device='cuda:0', progress_bar=True):
         self.model = model
         if isinstance(tokenizer, str):
             self.tokenizer = AutoTokenizer.from_pretrained(tokenizer)
@@ -18,6 +16,7 @@ class BaseZeroShotClassificationPipeline(ABC):
         self.max_classes = max_classes
         self.classification_type = classification_type
         self.max_length = max_length
+        self.progress_bar = progress_bar
 
         if torch.cuda.is_available() and 'cuda' in device:
             self.device = torch.device(device)
@@ -41,7 +40,12 @@ class BaseZeroShotClassificationPipeline(ABC):
             same_labels = False
         
         results = []
-        for idx in tqdm(range(0, len(texts), batch_size)):
+
+        iterable = range(0, len(texts), batch_size)
+        if self.progress_bar:
+            iterable = tqdm(iterable)
+
+        for idx in iterable:
             batch_texts = texts[idx:idx+batch_size]
             tokenized_inputs = self.prepare_inputs(batch_texts, labels, same_labels)
             model_output = self.model(**tokenized_inputs, output_text_embeddings=True,
@@ -71,9 +75,13 @@ class BaseZeroShotClassificationPipeline(ABC):
             same_labels = False
             
         results = []
-        for idx in tqdm(range(0, len(texts), batch_size)):
-            batch_texts = texts[idx:idx+batch_size]
 
+        iterable = range(0, len(texts), batch_size)
+        if self.progress_bar:
+            iterable = tqdm(iterable)
+
+        for idx in iterable:
+            batch_texts = texts[idx:idx+batch_size]
             tokenized_inputs = self.prepare_inputs(batch_texts, labels, same_labels)
             model_output = self.model(**tokenized_inputs)
             logits = model_output.logits
@@ -107,8 +115,8 @@ class BaseZeroShotClassificationPipeline(ABC):
     
 class UniEncoderZeroShotClassificationPipeline(BaseZeroShotClassificationPipeline):
     def __init__(self, model, tokenizer, max_classes=25, max_length=1024, 
-                                classification_type='multi-label', device='cuda:0'):
-        super().__init__(model, tokenizer, max_classes, max_length, classification_type, device)
+                                classification_type='multi-label', device='cuda:0', progress_bar=True):
+        super().__init__(model, tokenizer, max_classes, max_length, classification_type, device, progress_bar)
 
     def prepare_input(self, text, labels):
         input_text = []
@@ -140,8 +148,8 @@ class UniEncoderZeroShotClassificationPipeline(BaseZeroShotClassificationPipelin
 
 class EncoderDecoderZeroShotClassificationPipeline(BaseZeroShotClassificationPipeline):
     def __init__(self, model, tokenizer, max_classes=25, max_length=1024, 
-                                classification_type='multi-label', device='cuda:0'):
-        super().__init__(model, tokenizer, max_classes, max_length, classification_type, device)
+                                classification_type='multi-label', device='cuda:0', progress_bar=True):
+        super().__init__(model, tokenizer, max_classes, max_length, classification_type, device, progress_bar)
 
     def prepare_labels_prompt(self, labels):
         input_text = []
@@ -175,8 +183,8 @@ class EncoderDecoderZeroShotClassificationPipeline(BaseZeroShotClassificationPip
     
 class BiEncoderZeroShotClassificationPipeline(BaseZeroShotClassificationPipeline):
     def __init__(self, model, tokenizer, max_classes=25, max_length=1024, 
-                                classification_type='multi-label', device='cuda:0'):
-        super().__init__(model, tokenizer, max_classes, max_length, classification_type, device)
+                                classification_type='multi-label', device='cuda:0', progress_bar=True):
+        super().__init__(model, tokenizer, max_classes, max_length, classification_type, device, progress_bar)
 
     def prepare_inputs(self, texts, labels, same_labels=False):
         if same_labels:
@@ -218,18 +226,18 @@ class BiEncoderZeroShotClassificationPipeline(BaseZeroShotClassificationPipeline
 
 class ZeroShotClassificationPipeline:
     def __init__(self, model, tokenizer, max_classes=25, max_length=1024, 
-                                classification_type='multi-label', device='cuda:0'):
+                                classification_type='multi-label', device='cuda:0', progress_bar=True):
         if isinstance(model, str):
             model = GLiClassBiEncoder.from_pretrained(model)
         if model.config.architecture_type == 'uni-encoder':
             self.pipe = UniEncoderZeroShotClassificationPipeline(model, tokenizer, max_classes, 
-                                                                    max_length, classification_type, device)
+                                                                    max_length, classification_type, device, progress_bar)
         elif model.config.architecture_type in {'encoder-decoder'}:
             self.pipe = EncoderDecoderZeroShotClassificationPipeline(model, tokenizer, max_classes, 
-                                                                    max_length, classification_type, device)
+                                                                    max_length, classification_type, device, progress_bar)
         elif model.config.architecture_type == 'bi-encoder':
             self.pipe = BiEncoderZeroShotClassificationPipeline(model, tokenizer, max_classes, 
-                                                                    max_length, classification_type, device)
+                                                                    max_length, classification_type, device, progress_bar)
         else:
             raise NotImplementedError("This artchitecture is not implemented")
     
@@ -274,9 +282,14 @@ class ZeroShotClassificationWithLabelsChunkingPipeline(BaseZeroShotClassificatio
         return tokenized_inputs
     
     @torch.no_grad()
-    def __call__(self, texts, labels, threshold = 0.5, batch_size=8, labels_chunk_size=4): #labels - List[str]            
+    def __call__(self, texts, labels, threshold = 0.5, batch_size=8, labels_chunk_size=4): #labels - List[str]
         results = []
-        for idx in tqdm(range(0, len(texts), batch_size)):
+
+        iterable = range(0, len(texts), batch_size)
+        if self.progress_bar:
+            iterable = tqdm(iterable)
+
+        for idx in iterable:
             batch_texts = texts[idx:idx+batch_size]
 
             batch_results = []


### PR DESCRIPTION
In my own code, I am using tqdm and I noticed that whenever I was using ZeroShotClassificationPipeline, my tqdm progress bars would exhibit an annoying behavior of each iteration appearing on a new line. After reviewing my code, and attempting many ways to suppress this behavior, including trying another progress bar package (alive-progress) - I finally took a look at the GLiClass code. Upon review, I found that tqdm was also being used in the pipline.py code. Once I removed the usage of tqdm from the pipeline.py file on my local machine and the behavior of tqdm within my own code returned to normal.

Using tqdm within the library code itself will likely cause unintended issues with downstream usage that may also be using tqdm.

Regarding the removal of numpy and GLiClassModelConfig also appears to be inconsequential from my testing.

Thanks! 