### PR TITLE
Remove upper bound on transformers version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = ">=3.9,<4.0"
 torch = "^2.0.0"
-transformers = ">=4.37.2,<=4.47.1"
+transformers = ">=4.37.2"
 scikit-learn = "^1.0.0" 
 numpy = "^1.26.4"
 


### PR DESCRIPTION
- Updated transformers dependency from ">=4.37.2,<=4.47.1" to ">=4.37.2"
- Ensures compatibility with newer versions of the transformers library
- Fixes issue with 'modernbert' model type not being recognized