### PR TITLE
Bugfix/graph breaks

### DIFF
--- a/gliclass/config.py
+++ b/gliclass/config.py
@@ -41,7 +41,6 @@ class GLiClassModelConfig(PretrainedConfig):
         scorer_num_heads=16,
         scorer_mlp_hidden_size=1024,
         scorer_attn_dropout=0.1,
-        scorer_use_sequence_packing=True,
         pooling_strategy='first',
         class_token_pooling="first",
         focal_loss_alpha=0.5,
@@ -50,6 +49,7 @@ class GLiClassModelConfig(PretrainedConfig):
         logit_scale_init_value=2.6592,
         normalize_features=False,
         extract_text_features=False,
+        max_labels_alloc: str = 'dynamic',
         contrastive_loss_coef=0,
         architecture_type = 'uni-encoder',
         prompt_first = False,
@@ -67,8 +67,14 @@ class GLiClassModelConfig(PretrainedConfig):
                                                 else "deberta-v2")
             if encoder_config['model_type'] == 't5':
                 encoder_config = T5Config(**encoder_config)
-            else:
+            elif encoder_config["model_type"] in CONFIG_MAPPING:
                 encoder_config = CONFIG_MAPPING[encoder_config["model_type"]](**encoder_config)
+            else:
+                _name = encoder_model or kwargs.get("encoder_model_name")
+                if _name:
+                    encoder_config = AutoConfig.from_pretrained(_name, trust_remote_code=True)
+                else:
+                    encoder_config = PretrainedConfig(**encoder_config)
         elif encoder_config is None:
             encoder_config = CONFIG_MAPPING["deberta-v2"]()
 
@@ -123,7 +129,6 @@ class GLiClassModelConfig(PretrainedConfig):
         self.scorer_num_heads = scorer_num_heads
         self.scorer_mlp_hidden_size = scorer_mlp_hidden_size
         self.scorer_attn_dropout = scorer_attn_dropout
-        self.scorer_use_sequence_packing = scorer_use_sequence_packing
         self.pooling_strategy=pooling_strategy
         self.class_token_pooling=class_token_pooling
         self.use_lstm = use_lstm
@@ -134,6 +139,7 @@ class GLiClassModelConfig(PretrainedConfig):
         self.logit_scale_init_value = logit_scale_init_value
         self.normalize_features=normalize_features
         self.extract_text_features = extract_text_features
+        self.max_labels_alloc = max_labels_alloc
         self.architecture_type = architecture_type
         self.prompt_first = prompt_first
         self.squeeze_layers = squeeze_layers

--- a/gliclass/data_processing.py
+++ b/gliclass/data_processing.py
@@ -390,19 +390,35 @@ def pad_2d_tensor(key_data):
     return padded_tensors
 
 class DataCollatorWithPadding:
-    def __init__(self, device = 'cuda:0'):
+    def __init__(self, device='cuda:0', config=None):
         self.device = device
+        self._max_labels_alloc = getattr(config, 'max_labels_alloc', 'dynamic') if config is not None else 'dynamic'
+
+    def _resolve_max_num_classes(self, batch):
+        if self._max_labels_alloc == 'dynamic':
+            first = batch[0]
+            if 'labels_text' in first:
+                return max(len(item['labels_text']) for item in batch)
+            if 'labels_mask' in first:
+                return max(item['labels_mask'].shape[0] for item in batch)
+            first_labels = first.get('labels')
+            if isinstance(first_labels, torch.Tensor) and first_labels.dim() >= 1:
+                return max(item['labels'].shape[0] for item in batch)
+            return None
+        if isinstance(self._max_labels_alloc, int):
+            return self._max_labels_alloc
+        return None  # 'fixed': model uses config.max_num_classes
 
     def __call__(self, batch):
         keys = batch[0].keys()
         padded_batch = {key: [] for key in keys}
-        
+
         for key in keys:
             key_data = [item[key] for item in batch]
             if isinstance(key_data[0], torch.Tensor):
                 if  key_data[0].dim() == 1:
                     padded_batch[key] = pad_sequence(key_data, batch_first=True)
-                elif key_data[0].dim() == 2: 
+                elif key_data[0].dim() == 2:
                     padded_batch[key] = pad_2d_tensor(key_data)
             elif isinstance(key_data[0], list):
                 data_el = "string"
@@ -412,7 +428,7 @@ class DataCollatorWithPadding:
                     padded_batch[key] = key_data
                 else:
                     max_length = max(len(seq) for seq in key_data)
-                    padded_batch[key] = torch.tensor([seq + [0] * (max_length - len(seq)) 
+                    padded_batch[key] = torch.tensor([seq + [0] * (max_length - len(seq))
                                                         for seq in key_data])
             elif type(key_data[0]) in {int, float}:
                 padded_batch[key] = torch.tensor(key_data)
@@ -420,5 +436,6 @@ class DataCollatorWithPadding:
                 padded_batch[key] = key_data
             else:
                 raise TypeError(f"Unsupported data type: {type(key_data[0])}")
-        
+
+        padded_batch['max_num_classes'] = self._resolve_max_num_classes(batch)
         return padded_batch

--- a/gliclass/model.py
+++ b/gliclass/model.py
@@ -110,7 +110,6 @@ class GLiClassBaseModel(nn.Module):#):
                 num_heads=config.scorer_num_heads,
                 scorer_mlp_hidden_size=config.scorer_mlp_hidden_size,
                 attn_dropout=config.scorer_attn_dropout,
-                use_sequence_packing=config.scorer_use_sequence_packing,
             )
 
         if config.use_lstm:
@@ -134,13 +133,14 @@ class GLiClassBaseModel(nn.Module):#):
         
         self.device = torch.device(device)
 
-    def _extract_class_features(self, token_embeds, input_ids, attention_mask):
+    def _extract_class_features(self, token_embeds, input_ids, attention_mask, max_num_classes=None):
         batch_size, sequence_length, embed_dim = token_embeds.shape
 
         class_token_mask = input_ids == self.config.class_token_index
         num_class_tokens = torch.sum(class_token_mask, dim=-1, keepdim=True)
 
-        max_embed_dim = num_class_tokens.max()
+        # max_num_classes from caller (CPU int) avoids GPU→CPU sync via .item()
+        max_embed_dim = max_num_classes if max_num_classes is not None else self.config.max_num_classes
         
         # Get class token pooling method from config (default to "first" for backward compatibility)
         class_token_pooling = getattr(self.config, 'class_token_pooling', 'first')
@@ -161,152 +161,82 @@ class GLiClassBaseModel(nn.Module):#):
         # Text features extraction
         if self.config.extract_text_features:
             text_token_mask = input_ids == self.config.text_token_index
-            
-            # Get text token start index per batch item (assuming one text token per batch)
-            # Shape: (batch_size,)
-            text_token_indices = text_token_mask.int().argmax(dim=-1)
-            
-            # Calculate text lengths per batch item
-            text_lengths = input_ids.shape[-1] - text_token_indices  # Shape: (batch_size,)
-            max_text_length = text_lengths.max().item()
-            
-            text_tokens_embeddings = torch.zeros(
-                batch_size, max_text_length, embed_dim, 
-                dtype=token_embeds.dtype, device=token_embeds.device
-            )
-            text_tokens_mask = torch.zeros(
-                batch_size, max_text_length, 
-                dtype=attention_mask.dtype, device=token_embeds.device
-            )
-            
-            # Create range tensor for target indices: (batch_size, max_text_length)
+            text_token_indices = text_token_mask.int().argmax(dim=-1)  # (batch,)
+            max_text_length = input_ids.shape[-1]  # static, no GPU→CPU sync
+
+            # (batch, max_text_length): source position in token_embeds for each target slot
             aranged_target_idx = torch.arange(
                 max_text_length, device=token_embeds.device
             ).unsqueeze(0).expand(batch_size, -1)
-            
-            # Mask for valid positions: (batch_size, max_text_length)
-            valid_mask = aranged_target_idx < text_lengths.unsqueeze(1)
-            
-            # Get batch and target indices where valid
-            batch_idx, target_text_idx = torch.where(valid_mask)
-            
-            # Calculate corresponding source indices in token_embeds
-            source_text_idx = text_token_indices[batch_idx] + target_text_idx
-            
-            # Assign embeddings and mask
-            text_tokens_embeddings[batch_idx, target_text_idx] = token_embeds[batch_idx, source_text_idx]
-            text_tokens_mask[batch_idx, target_text_idx] = attention_mask[batch_idx, source_text_idx]
+            valid_mask = aranged_target_idx < (input_ids.shape[-1] - text_token_indices).unsqueeze(1)
+
+            source_indices = (text_token_indices.unsqueeze(1) + aranged_target_idx).clamp(
+                max=input_ids.shape[-1] - 1
+            )
+            batch_arange = torch.arange(batch_size, device=token_embeds.device).unsqueeze(1)
+
+            # Gather then zero-out invalid positions — no nonzero/scatter needed
+            text_tokens_embeddings = token_embeds[batch_arange, source_indices] * valid_mask.unsqueeze(-1).to(token_embeds.dtype)
+            text_tokens_mask = attention_mask[batch_arange, source_indices] * valid_mask
         else:
             text_tokens_embeddings = token_embeds
             text_tokens_mask = attention_mask
         return classes_embedding, classes_embedding_mask, text_tokens_embeddings, text_tokens_mask
 
-    def _extract_class_features_first(self, token_embeds, input_ids, attention_mask, 
-                                       class_token_mask, num_class_tokens, max_embed_dim, 
+    def _extract_class_features_first(self, token_embeds, input_ids, attention_mask,
+                                       class_token_mask, num_class_tokens, max_embed_dim,
                                        batch_size, embed_dim):
-        """Original method: extract only the class token embedding (or token after it)."""
-        aranged_class_idx = torch.arange(max_embed_dim, 
-                                            dtype=attention_mask.dtype, 
-                                            device=token_embeds.device).expand(batch_size, -1)
-        
-        batch_indices, target_class_idx = torch.where(aranged_class_idx < num_class_tokens)
-        _, class_indices = torch.where(class_token_mask)
+        """Extract only the class token embedding (or token after it). Fully vectorized."""
+        class_cum = class_token_mask.long().cumsum(dim=-1)  # (batch, seq)
+        k_range = torch.arange(max_embed_dim, device=token_embeds.device).view(1, -1, 1)
+
+        # select_mask[b, k, s] = True at the position of the k-th class token
+        select_mask = class_token_mask.unsqueeze(1) & ((class_cum.unsqueeze(1) - 1) == k_range)
+
         if not self.config.embed_class_token:
-            class_indices += 1
+            # Shift right by 1: select the token immediately after each class token
+            shifted = torch.zeros_like(select_mask)
+            shifted[:, :, 1:] = select_mask[:, :, :-1]
+            select_mask = shifted
 
-        classes_embedding = torch.zeros(
-            batch_size, max_embed_dim, embed_dim, dtype=token_embeds.dtype, device=token_embeds.device
-        )
-        classes_embedding_mask = torch.zeros(
-            batch_size, max_embed_dim, dtype=attention_mask.dtype, device=token_embeds.device
-        )
+        classes_embedding = torch.einsum('bks,bsd->bkd', select_mask.to(token_embeds.dtype), token_embeds)
 
-        classes_embedding[batch_indices, target_class_idx] = token_embeds[batch_indices, class_indices]
-        classes_embedding_mask[batch_indices, target_class_idx] = 1
-        
+        arange_k = torch.arange(max_embed_dim, device=token_embeds.device).unsqueeze(0)
+        classes_embedding_mask = (arange_k < num_class_tokens).to(attention_mask.dtype)
+
         return classes_embedding, classes_embedding_mask
 
     def _extract_class_features_averaged(self, token_embeds, input_ids, attention_mask,
                                           class_token_mask, num_class_tokens, max_embed_dim,
                                           batch_size, embed_dim):
-        """
-        Average all tokens belonging to each class label.
-        
-        For each class, we average tokens from:
-        - Start: class token position (or position + 1 if embed_class_token is False)
-        - End: next class token position (or text token position, or end of valid tokens)
-        """
-        classes_embedding = torch.zeros(
-            batch_size, max_embed_dim, embed_dim, dtype=token_embeds.dtype, device=token_embeds.device
-        )
-        classes_embedding_mask = torch.zeros(
-            batch_size, max_embed_dim, dtype=attention_mask.dtype, device=token_embeds.device
-        )
-        
-        # Get text token positions as boundary markers
+        """Average all tokens belonging to each class label. Fully vectorized."""
+        # class_cum[b, s] = cumulative count of class tokens up to position s
+        class_cum = class_token_mask.long().cumsum(dim=-1)  # (batch, seq)
+
         if self.config.extract_text_features:
-            text_token_mask = input_ids == self.config.text_token_index
+            text_token_mask = (input_ids == self.config.text_token_index)
         else:
             text_token_mask = torch.zeros_like(class_token_mask)
-        
-        for batch_idx in range(batch_size):
-            # Get class token positions for this batch item
-            class_positions = torch.where(class_token_mask[batch_idx])[0]
-            n_classes = len(class_positions)
-            
-            if n_classes == 0:
-                continue
-            
-            # Get text token position (boundary for last class)
-            text_positions = torch.where(text_token_mask[batch_idx])[0]
-            if len(text_positions) > 0:
-                text_start = text_positions[0].item()
-            else:
-                # If no text token, use sequence length
-                text_start = attention_mask[batch_idx].sum().item()
-            
-            for class_idx in range(n_classes):
-                class_pos = class_positions[class_idx].item()
-                
-                # Determine start position
-                if self.config.embed_class_token:
-                    start_pos = class_pos
-                else:
-                    start_pos = class_pos + 1
-                
-                # Determine end position (exclusive)
-                if class_idx + 1 < n_classes:
-                    # Next class token position
-                    end_pos = class_positions[class_idx + 1].item()
-                else:
-                    # Text token position or end of valid sequence
-                    end_pos = text_start
-                
-                # Ensure valid range
-                if start_pos >= end_pos:
-                    # Fallback: just use the single token
-                    if self.config.embed_class_token:
-                        classes_embedding[batch_idx, class_idx] = token_embeds[batch_idx, class_pos]
-                    else:
-                        if class_pos + 1 < token_embeds.shape[1]:
-                            classes_embedding[batch_idx, class_idx] = token_embeds[batch_idx, class_pos + 1]
-                else:
-                    # Extract tokens for this class and average them
-                    class_tokens = token_embeds[batch_idx, start_pos:end_pos]  # (span_length, embed_dim)
-                    class_attn = attention_mask[batch_idx, start_pos:end_pos]  # (span_length,)
-                    
-                    # Masked average (only average over attended tokens)
-                    attn_sum = class_attn.sum()
-                    if attn_sum > 0:
-                        # Weighted average by attention mask
-                        class_tokens_masked = class_tokens * class_attn.unsqueeze(-1).float()
-                        classes_embedding[batch_idx, class_idx] = class_tokens_masked.sum(dim=0) / attn_sum.float()
-                    else:
-                        # Fallback to simple mean if no attention
-                        classes_embedding[batch_idx, class_idx] = class_tokens.mean(dim=0)
-                
-                classes_embedding_mask[batch_idx, class_idx] = 1
-        
+        # text_cum[b, s] >= 1 at and after the text token → use as exclusion boundary
+        text_cum = text_token_mask.long().cumsum(dim=-1)  # (batch, seq)
+
+        # span_mask[b, k, s] = True if token s belongs to the span of class k
+        k_range = torch.arange(max_embed_dim, device=token_embeds.device).view(1, -1, 1)
+        span_mask = (
+            (class_cum.unsqueeze(1) == (k_range + 1))  # in the span of class k
+            & (text_cum.unsqueeze(1) == 0)             # before the text boundary
+            & attention_mask.unsqueeze(1).bool()        # real token (not padding)
+        )
+        if not self.config.embed_class_token:
+            span_mask = span_mask & ~class_token_mask.unsqueeze(1)
+
+        span_float = span_mask.to(token_embeds.dtype)  # (batch, max_embed_dim, seq)
+        class_counts = span_float.sum(dim=-1, keepdim=True).clamp(min=1)
+        classes_embedding = torch.einsum('bks,bsd->bkd', span_float, token_embeds) / class_counts
+
+        arange_k = torch.arange(max_embed_dim, device=token_embeds.device).unsqueeze(0)
+        classes_embedding_mask = (arange_k < num_class_tokens).to(attention_mask.dtype)
+
         return classes_embedding, classes_embedding_mask
 
     def get_loss(self, logits, labels, classes_embedding=None, classes_embedding_mask=None):
@@ -411,6 +341,11 @@ class GLiClassUniEncoder(GLiClassBaseModel):
                         config.encoder_config
                     )
 
+        if config.vocab_size is not None and hasattr(self.encoder_model, 'resize_token_embeddings'):
+            current_vocab = self.encoder_model.config.vocab_size
+            if current_vocab != config.vocab_size:
+                self.encoder_model.resize_token_embeddings(config.vocab_size)
+
         adapter_config_file = Path(config.encoder_model_name) / "adapter_config.json"
 
         if adapter_config_file.exists():
@@ -449,9 +384,9 @@ class GLiClassUniEncoder(GLiClassBaseModel):
 
         return segment_ids
 
-    def process_encoder_output(self, input_ids, attention_mask, encoder_layer, labels = None):
-        classes_embedding, classes_embedding_mask, text_token_embeddings, text_mask = self._extract_class_features(encoder_layer, 
-                                                                                                            input_ids, attention_mask)
+    def process_encoder_output(self, input_ids, attention_mask, encoder_layer, labels=None, max_num_classes=None):
+        classes_embedding, classes_embedding_mask, text_token_embeddings, text_mask = self._extract_class_features(encoder_layer,
+                                                                                                            input_ids, attention_mask, max_num_classes)
         if self.config.use_lstm:
             text_token_embeddings = self.lstm(text_token_embeddings, text_mask)
         
@@ -484,6 +419,7 @@ class GLiClassUniEncoder(GLiClassBaseModel):
         output_text_embeddings: Optional[bool] = None,
         output_class_embeddings:  Optional[bool] = None,
         return_dict: Optional[bool] = None,
+        max_num_classes: Optional[int] = None,
         **kwargs
     ) -> Union[Tuple, GLiClassOutput]:
         r"""
@@ -529,7 +465,7 @@ class GLiClassUniEncoder(GLiClassBaseModel):
             hidden_states = outputs.hidden_states
             loss = 0
             for encoder_layer in hidden_states:
-                logits, layer_loss, pooled_output, classes_embedding = self.process_encoder_output(input_ids, attention_mask, encoder_layer, labels)
+                logits, layer_loss, pooled_output, classes_embedding = self.process_encoder_output(input_ids, attention_mask, encoder_layer, labels, max_num_classes)
                 loss+=layer_loss
         else:
             if self.config.encoder_layer_id==-1:
@@ -539,7 +475,7 @@ class GLiClassUniEncoder(GLiClassBaseModel):
                     encoder_layer = outputs[0]
             else:
                 encoder_layer = outputs.hidden_states[self.config.encoder_layer_id]
-            logits, loss, pooled_output, classes_embedding = self.process_encoder_output(input_ids, attention_mask, encoder_layer, labels)
+            logits, loss, pooled_output, classes_embedding = self.process_encoder_output(input_ids, attention_mask, encoder_layer, labels, max_num_classes)
 
         if not return_dict:
             output = (logits,) + outputs[1:]

--- a/gliclass/ops.py
+++ b/gliclass/ops.py
@@ -1,116 +1,6 @@
 import torch
 import torch.nn.functional as F
 
-try:
-    from flash_attn import flash_attn_varlen_func
-    FLASH_ATTN_AVAILABLE = True
-except ImportError:
-    FLASH_ATTN_AVAILABLE = False
-
-
-# ─── Padding helpers ──────────────────────────────────────────────────────────
-
-@torch.compiler.disable
-def _get_unpad_data(attention_mask: torch.Tensor):
-    seqlens = attention_mask.sum(dim=-1, dtype=torch.int32)
-    indices = torch.nonzero(attention_mask.flatten(), as_tuple=False).flatten()
-    max_seqlen = seqlens.max().item()
-    cu_seqlens = F.pad(torch.cumsum(seqlens, dim=0, dtype=torch.int32), (1, 0))
-    return indices, cu_seqlens, max_seqlen
-
-
-def unpad_input(hidden_states: torch.Tensor, attention_mask: torch.Tensor):
-    """
-    Remove padding from a batch of sequences.
-
-    Args:
-        hidden_states: (batch, seqlen, ...)
-        attention_mask: (batch, seqlen)  1 = real token, 0 = pad
-    Returns:
-        hidden_states_unpadded: (total_nnz, ...)
-        indices:                (total_nnz,)
-        cu_seqlens:             (batch + 1,) int32
-        max_seqlen:             int
-    """
-    indices, cu_seqlens, max_seqlen = _get_unpad_data(attention_mask)
-    flat = hidden_states.reshape(-1, *hidden_states.shape[2:])
-    return flat[indices], indices, cu_seqlens, max_seqlen
-
-
-def pad_input(hidden_states: torch.Tensor, indices: torch.Tensor, batch: int, seqlen: int):
-    """
-    Restore padding after unpadded processing.
-
-    Args:
-        hidden_states: (total_nnz, ...)
-        indices:       (total_nnz,)
-        batch:         int
-        seqlen:        int (max seqlen)
-    Returns:
-        (batch, seqlen, ...)
-    """
-    output = hidden_states.new_zeros(batch * seqlen, *hidden_states.shape[1:])
-    output = output.index_put((indices,), hidden_states)
-    return output.reshape(batch, seqlen, *hidden_states.shape[1:])
-
-
-# ─── Attention (varlen) ───────────────────────────────────────────────────────
-
-def _attn_varlen_torch(q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale):
-    """Pure PyTorch fallback for unpadded variable-length attention."""
-    B = cu_seqlens_q.shape[0] - 1
-    out = torch.zeros_like(q)
-
-    for b in range(B):
-        qs, qe = cu_seqlens_q[b].item(), cu_seqlens_q[b + 1].item()
-        ks, ke = cu_seqlens_k[b].item(), cu_seqlens_k[b + 1].item()
-        if qe == qs or ke == ks:
-            continue
-        attn = torch.einsum('qhd,khd->hqk', q[qs:qe], k[ks:ke]) * sm_scale
-        attn = F.softmax(attn, dim=-1)
-        out[qs:qe] = torch.einsum('hqk,khd->qhd', attn, v[ks:ke])
-
-    return out
-
-
-def attn_varlen(
-    q: torch.Tensor,
-    k: torch.Tensor,
-    v: torch.Tensor,
-    cu_seqlens_q: torch.Tensor,
-    cu_seqlens_k: torch.Tensor,
-    sm_scale: float | None = None,
-    dropout_p: float = 0.0,
-) -> torch.Tensor:
-    """
-    Unpadded attention with variable-length sequences.
-    Priority: flash_attn → PyTorch loop.
-
-    Args:
-        q:            [total_q, nheads, head_dim]
-        k:            [total_k, nheads, head_dim]
-        v:            [total_k, nheads, head_dim]
-        cu_seqlens_q: [B+1] int32
-        cu_seqlens_k: [B+1] int32
-        sm_scale:     defaults to 1/sqrt(head_dim)
-    """
-    if sm_scale is None:
-        sm_scale = q.shape[-1] ** -0.5
-
-    if FLASH_ATTN_AVAILABLE and q.is_cuda:
-        max_seqlen_q = int((cu_seqlens_q[1:] - cu_seqlens_q[:-1]).max())
-        max_seqlen_k = int((cu_seqlens_k[1:] - cu_seqlens_k[:-1]).max())
-        return flash_attn_varlen_func(
-            q, k, v,
-            cu_seqlens_q, cu_seqlens_k,
-            max_seqlen_q, max_seqlen_k,
-            dropout_p=dropout_p,
-            softmax_scale=sm_scale,
-            causal=False,
-        )
-
-    return _attn_varlen_torch(q, k, v, cu_seqlens_q, cu_seqlens_k, sm_scale)
-
 
 # ─── Attention (padded) ───────────────────────────────────────────────────────
 
@@ -139,7 +29,7 @@ def attn_padded(
 
     attn_mask = None
     if key_padding_mask is not None:
-        attn_mask = key_padding_mask[:, None, None, :]
+        attn_mask = key_padding_mask[:, None, None, :].bool()
 
     out = F.scaled_dot_product_attention(
         q, k, v,

--- a/gliclass/pipeline.py
+++ b/gliclass/pipeline.py
@@ -190,7 +190,8 @@ class BaseZeroShotClassificationPipeline(ABC):
         self.max_length = max_length
         self.progress_bar = progress_bar
         self.label_separator = label_separator
-        
+        self._max_labels_alloc = getattr(model.config, 'max_labels_alloc', 'dynamic')
+
         self.example_token = "<<EXAMPLE>>"
         self.label_token = "<<LABEL>>"
         self.sep_token = "<<SEP>>"
@@ -277,6 +278,13 @@ class BaseZeroShotClassificationPipeline(ABC):
         
         return ""
 
+    def _resolve_max_num_classes(self, batch_labels, same_labels: bool):
+        if self._max_labels_alloc == 'dynamic':
+            return len(batch_labels) if same_labels else max(len(l) for l in batch_labels)
+        if isinstance(self._max_labels_alloc, int):
+            return self._max_labels_alloc
+        return None  # 'fixed': model uses config.max_num_classes
+
     @abstractmethod
     def prepare_inputs(self, texts, labels, same_labels=False, examples=None, prompt=None):
         pass
@@ -321,11 +329,13 @@ class BaseZeroShotClassificationPipeline(ABC):
             batch_prompt = self._get_batch_prompt(prompt, idx, len(batch_texts))
             
             tokenized_inputs = self.prepare_inputs(
-                batch_texts, labels, same_labels, 
+                batch_texts, labels, same_labels,
                 examples=batch_examples, prompt=batch_prompt
             )
+            max_num_classes = self._resolve_max_num_classes(labels, same_labels)
             model_output = self.model(
-                **tokenized_inputs, 
+                **tokenized_inputs,
+                max_num_classes=max_num_classes,
                 output_text_embeddings=True,
                 output_class_embeddings=True
             )
@@ -410,10 +420,11 @@ class BaseZeroShotClassificationPipeline(ABC):
             batch_prompt = self._get_batch_prompt(prompt, idx, len(batch_texts))
             
             tokenized_inputs = self.prepare_inputs(
-                batch_texts, batch_labels, same_labels, 
+                batch_texts, batch_labels, same_labels,
                 examples=batch_examples, prompt=batch_prompt
             )
-            model_output = self.model(**tokenized_inputs)
+            max_num_classes = self._resolve_max_num_classes(batch_labels, same_labels)
+            model_output = self.model(**tokenized_inputs, max_num_classes=max_num_classes)
             logits = model_output.logits
             
             if self.classification_type == 'single-label':
@@ -1068,10 +1079,11 @@ class ZeroShotClassificationWithChunkingPipeline(BaseZeroShotClassificationPipel
                 all_labels.extend(curr_labels)
                 
                 tokenized_inputs = self.prepare_inputs(
-                    [text_chunk], curr_labels, same_labels=True, 
+                    [text_chunk], curr_labels, same_labels=True,
                     examples=examples, prompt=prompt
                 )
-                model_output = self.model(**tokenized_inputs)
+                max_num_classes = self._resolve_max_num_classes(curr_labels, same_labels=True)
+                model_output = self.model(**tokenized_inputs, max_num_classes=max_num_classes)
                 logits = model_output.logits
                 
                 chunk_logits.extend(logits[0][:len(curr_labels)].tolist())
@@ -1178,10 +1190,11 @@ class ZeroShotClassificationWithChunkingPipeline(BaseZeroShotClassificationPipel
 
                     batch_prompt = self._get_batch_prompt(prompt, idx, len(batch_texts))
                     tokenized_inputs = self.prepare_inputs(
-                        batch_texts, curr_labels, same_labels=True, 
+                        batch_texts, curr_labels, same_labels=True,
                         examples=examples, prompt=batch_prompt
                     )
-                    model_output = self.model(**tokenized_inputs)
+                    max_num_classes = self._resolve_max_num_classes(curr_labels, same_labels=True)
+                    model_output = self.model(**tokenized_inputs, max_num_classes=max_num_classes)
                     logits = model_output.logits
 
                     for i in range(len(batch_texts)):

--- a/gliclass/scorers.py
+++ b/gliclass/scorers.py
@@ -1,6 +1,6 @@
 import torch
 from torch import nn
-from .ops import attn_varlen, attn_padded, unpad_input, pad_input
+from .ops import attn_padded
 
 class ScorerWeightedDot(nn.Module):
     def __init__(self, hidden_size, dropout=0.1, **kwargs):
@@ -121,14 +121,13 @@ class HopfieldScorer(nn.Module):
         return scores
 
 class CrossAttnScorer(nn.Module):
-    def __init__(self, hidden_size, num_heads=16, attn_dropout=0.1, scorer_mlp_hidden_size=1024, use_sequence_packing=True, **kwargs):
+    def __init__(self, hidden_size, num_heads=16, attn_dropout=0.1, scorer_mlp_hidden_size=1024, **kwargs):
         super().__init__()
         assert hidden_size % num_heads == 0, \
             f"hidden_size {hidden_size} must be divisible by num_heads {num_heads}"
-        self.num_heads            = num_heads
-        self.head_dim             = hidden_size // num_heads
-        self.attn_dropout         = attn_dropout
-        self.use_sequence_packing = use_sequence_packing
+        self.num_heads  = num_heads
+        self.head_dim   = hidden_size // num_heads
+        self.attn_dropout = attn_dropout
 
         self.q_norm  = nn.LayerNorm(hidden_size)
         self.kv_norm = nn.LayerNorm(hidden_size)
@@ -148,46 +147,6 @@ class CrossAttnScorer(nn.Module):
             nn.Linear(scorer_mlp_hidden_size // 2, 1),
         )
 
-    def _forward_packed(self, text_rep, label_rep, text_mask, batch_size, num_labels, hidden_size):
-        """Unpadded path: flash_attn_varlen → PyTorch loop fallback."""
-        label_mask = label_rep.abs().sum(dim=-1) > 0  # [B, N]
-
-        text_unpad,  _, cu_seqlens_k, _            = unpad_input(text_rep,  text_mask)
-        label_unpad, label_indices, cu_seqlens_q, _ = unpad_input(label_rep, label_mask)
-
-        q = self.q(self.q_norm(label_unpad)).view(-1, self.num_heads, self.head_dim)
-        k = self.k(self.kv_norm(text_unpad)).view(-1, self.num_heads, self.head_dim)
-        v = self.v(text_unpad).view(-1, self.num_heads, self.head_dim)
-
-        dropout_p = self.attn_dropout if self.training else 0.0
-        context = attn_varlen(q, k, v, cu_seqlens_q, cu_seqlens_k, dropout_p=dropout_p)
-        context = self.norm(self.out(context.reshape(-1, hidden_size)))  # [Ql, H]
-
-        scores_unpad = self.score_mlp(
-            torch.cat([context, label_unpad], dim=-1)
-        ).squeeze(-1)  # [Ql]
-
-        return pad_input(
-            scores_unpad.unsqueeze(-1), label_indices, batch_size, num_labels
-        ).squeeze(-1)  # [B, N]
-
-    def _forward_padded(self, text_rep, label_rep, text_mask, batch_size, num_labels, hidden_size):
-        """Padded path: F.scaled_dot_product_attention (flash backend on CUDA)."""
-        q = self.q(self.q_norm(label_rep)).view(batch_size, num_labels, self.num_heads, self.head_dim)
-        k = self.k(self.kv_norm(text_rep)).view(batch_size, -1, self.num_heads, self.head_dim)
-        v = self.v(text_rep).view(batch_size, -1, self.num_heads, self.head_dim)
-
-        dropout_p = self.attn_dropout if self.training else 0.0
-        context = attn_padded(q, k, v, key_padding_mask=text_mask, dropout_p=dropout_p)
-        # [B, N, nheads, head_dim] → [B, N, H]
-        context = self.norm(self.out(context.reshape(batch_size, num_labels, hidden_size)))
-
-        scores = self.score_mlp(
-            torch.cat([context, label_rep], dim=-1)
-        ).squeeze(-1)  # [B, N]
-
-        return scores
-
     def forward(self, text_rep, label_rep, text_mask=None, **kwargs):
         batch_size, _, hidden_size = text_rep.shape
         num_labels = label_rep.shape[1]
@@ -196,10 +155,17 @@ class CrossAttnScorer(nn.Module):
             text_mask = torch.ones(batch_size, text_rep.shape[1],
                                    dtype=torch.bool, device=text_rep.device)
 
-        if self.use_sequence_packing:
-            return self._forward_packed(text_rep, label_rep, text_mask, batch_size, num_labels, hidden_size)
-        else:
-            return self._forward_padded(text_rep, label_rep, text_mask, batch_size, num_labels, hidden_size)
+        q = self.q(self.q_norm(label_rep)).view(batch_size, num_labels, self.num_heads, self.head_dim)
+        k = self.k(self.kv_norm(text_rep)).view(batch_size, -1, self.num_heads, self.head_dim)
+        v = self.v(text_rep).view(batch_size, -1, self.num_heads, self.head_dim)
+
+        dropout_p = self.attn_dropout if self.training else 0.0
+        context = attn_padded(q, k, v, key_padding_mask=text_mask, dropout_p=dropout_p)
+        context = self.norm(self.out(context.reshape(batch_size, num_labels, hidden_size)))
+
+        return self.score_mlp(
+            torch.cat([context, label_rep], dim=-1)
+        ).squeeze(-1)
 
 
 SCORER2OBJECT = {


### PR DESCRIPTION
Removed all torch.compile graph breaks: vectorized class/text feature extraction to eliminate .item() and torch.where calls, replaced the varlen attention path with padded SDPA, moved max_num_classes computation to the pipeline/collator so it arrives as a plain Python int. The model now compiles to a single graph in all allocation modes (dynamic, fixed, or explicit int).